### PR TITLE
Add .gitignore with Python virtual environment patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,40 @@
+# Python virtual environments
+**/venv/
+**/env/
+**/.env/
+**/.venv/
+**/ENV/
+**/*.pyc
+**/__pycache__/
+**/.Python
+.env
+.python-version
+.env.local
+.env.*.local
+
+# IDE settings
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# Python artifacts
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg


### PR DESCRIPTION
This PR addresses an issue that displayed numerous Git changes and warnings in the Cloud Code OSS IDE.

I added a .gitignore file to exclude all the venv and Python-related folders from Git.